### PR TITLE
Eliminar is_siteadmin() para respetar capabilities locales y cambio de rol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Todos los cambios notables de este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/),
 y este proyecto adhiere al [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] — 2026-01-18
+
+### Corregido
+- Se eliminaron las comprobaciones redundantes de administrador (`is_siteadmin()`) en varias vistas clave, mejorando la detección correcta de roles locales (profesores vs estudiantes) y el sistema de permisos basado en capacidades.
+
 ## [2.0.2] — 2026-01-18
 
 ### Agregado

--- a/admin_view.php
+++ b/admin_view.php
@@ -33,7 +33,7 @@ if (!$DB->record_exists('block_instances', array('blockname' => 'chaside', 'pare
 }
 
 // Silent redirect
-if (!has_capability('block/chaside:viewreports', $context) && !is_siteadmin()) {
+if (!has_capability('block/chaside:viewreports', $context)) {
     redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
 }
 
@@ -51,11 +51,8 @@ if ($action === 'delete' && $userid && confirm_sesskey()) {
     $confirm = optional_param('confirm', 0, PARAM_INT);
     if ($confirm) {
         $targetuser = $DB->get_record('user', array('id' => $userid), '*', MUST_EXIST);
-        if (!is_siteadmin() && (
-            !is_enrolled($context, $targetuser, 'block/chaside:take_test', true)
-            || has_capability('block/chaside:viewreports', $context, $userid)
-            || is_siteadmin($userid)
-        )) {
+        if (!is_enrolled($context, $targetuser, 'block/chaside:take_test', true)
+            || has_capability('block/chaside:viewreports', $context, $userid)) {
             redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
         }
         $DB->delete_records('block_chaside_responses', array('userid' => $userid));

--- a/lib.php
+++ b/lib.php
@@ -26,7 +26,7 @@ function block_chaside_get_completed_responses($courseid, $groupid = 0) {
     require_login($course, false);
     
     // Check permissions
-    if (!has_capability('block/chaside:viewreports', $context) && !has_capability('block/chaside:manage_responses', $context) && !is_siteadmin()) {
+    if (!has_capability('block/chaside:viewreports', $context) && !has_capability('block/chaside:manage_responses', $context)) {
         return false;
     }
     
@@ -65,9 +65,7 @@ function block_chaside_get_student_ids($context, $groupid = 0) {
     $student_ids = array();
     foreach ($enrolled_ids as $candidateid) {
         $candidateid = (int)$candidateid;
-        if (is_siteadmin($candidateid)) {
-            continue;
-        }
+        
         if (has_capability('block/chaside:viewreports', $context, $candidateid) || has_capability('block/chaside:manage_responses', $context, $candidateid)) {
             continue;
         }

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -52,7 +52,7 @@
 
     <div class="chaside-actions text-center mt-3">
         <a href="{{dashboard_url}}" class="btn btn-sm btn-block" style="background: linear-gradient(135deg, #ffb600 0%, #e6a300 100%); border-color: #ffb600; color: #fff;">
-            <i class="fa fa-chart-bar"></i> {{str_admin_dashboard}}
+            {{str_admin_dashboard}}
         </a>
     </div>
 </div>
@@ -184,7 +184,7 @@
 
     <div class="chaside-actions text-center">
         <a href="{{view_results_url}}" class="btn btn-sm" style="background: linear-gradient(135deg, #ffb600 0%, #e6a300 100%); border-color: #ffb600; color: #fff; border: none; color: #fff; width: 100%; font-weight: 500;">
-            <i class="fa fa-chart-bar"></i> {{str_view_detailed_results}}
+            <i class="fa fa-eye"></i> {{str_view_detailed_results}}
         </a>
     </div>
 </div>

--- a/version.php
+++ b/version.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Chaside Block Major Update
- * Version 2.0.2 - Production Ready
+ * Version 2.0.3 - Production Ready
  *
  * @package    block_chaside
  * @copyright  2026 Jairo Serrano, Yuranis Henriquez, Isaac Sanchez, Santiago Orejuela, Maria Valentina
@@ -10,8 +10,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026011800; // YYYYMMDDXX (year, month, day, 2-digit version number).
+$plugin->version = 2026011801; // YYYYMMDDXX (year, month, day, 2-digit version number).
 $plugin->requires = 2022041900; // Moodle 4.0+
 $plugin->component = 'block_chaside';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.0.2';
+$plugin->release = '2.0.3';


### PR DESCRIPTION
Este PR corrige la lógica de permisos del bloque para que respete el contexto del curso en lugar de los permisos globales del sitio.

### Cambios realizados:
- Se eliminaron las llamadas a `is_siteadmin()` y `!is_siteadmin()` en la lógica de acceso y generación de reportes.
- Ahora el acceso se determina exclusivamente mediante `has_capability('block/pluginname:viewreports', $context)`.

### Beneficios:
- **QA Mejorado:** Permite a los administradores usar la función "Cambiar rol a -> Estudiante" y ver el bloque exactamente como lo vería un alumno.
- **Consistencia:** Si un admin se matricula como estudiante en un curso, ahora aparecerá correctamente en los reportes y listas de clase en lugar de ser filtrado automáticamente.