### PR TITLE
Renovación SAVIO: permisos y panel protegido de Orientación Vocacional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Todos los cambios notables de este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/),
 y este proyecto adhiere al [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] — 2026-07-28
+
+### Cambiado
+- El bloque reemplaza la vista de métricas en el curso por un lanzador compacto y consistente hacia el panel administrativo.
+- Se actualizaron las vistas de administración, resultados, botones y textos bilingües para el nuevo flujo de exploración.
+
+### Seguridad
+- Se añadieron las capacidades `viewstudentdata` y `deletestudentdata` para controlar de manera independiente la consulta/exportación y el borrado de respuestas.
+- Los roles docentes no reciben acceso automático a datos sensibles.
+- Se eliminaron las capacidades heredadas e inactivas `viewreports` y `manage_responses`.
+
 ## [2.0.3] — 2026-01-18
 
 ### Corregido

--- a/admin_view.php
+++ b/admin_view.php
@@ -33,7 +33,7 @@ if (!$DB->record_exists('block_instances', array('blockname' => 'chaside', 'pare
 }
 
 // Silent redirect
-if (!has_capability('block/chaside:viewreports', $context)) {
+if (!has_capability('block/chaside:viewstudentdata', $context)) {
     redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
 }
 
@@ -47,12 +47,16 @@ $admin_url = new moodle_url('/blocks/chaside/admin_view.php', array('courseid' =
 $PAGE->set_url($admin_url);
 
 // Process actions
+if ($action === 'delete' && $userid && !has_capability('block/chaside:deletestudentdata', $context)) {
+    redirect($admin_url);
+}
+
 if ($action === 'delete' && $userid && confirm_sesskey()) {
     $confirm = optional_param('confirm', 0, PARAM_INT);
     if ($confirm) {
         $targetuser = $DB->get_record('user', array('id' => $userid), '*', MUST_EXIST);
         if (!is_enrolled($context, $targetuser, 'block/chaside:take_test', true)
-            || has_capability('block/chaside:viewreports', $context, $userid)) {
+            || has_capability('block/chaside:viewstudentdata', $context, $userid)) {
             redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
         }
         $DB->delete_records('block_chaside_responses', array('userid' => $userid));
@@ -61,7 +65,7 @@ if ($action === 'delete' && $userid && confirm_sesskey()) {
 }
 
 $title = get_string('admin_dashboard', 'block_chaside');
-$PAGE->set_pagelayout('standard');
+$PAGE->set_pagelayout('incourse');
 $PAGE->set_title($title . " : " . $course->fullname);
 $PAGE->set_heading($title . " : " . $course->fullname);
 $PAGE->requires->css(new moodle_url('/blocks/chaside/styles.css'));
@@ -76,7 +80,8 @@ $data = [
     'admin_url' => $admin_url->out(false),
     'export_url' => (new moodle_url('/blocks/chaside/export.php', ['courseid' => $courseid, 'format' => 'csv']))->out(false),
     'course_url' => (new moodle_url('/course/view.php', ['id' => $courseid]))->out(false),
-    'search_term' => $search
+    'search_term' => $search,
+    'can_delete' => has_capability('block/chaside:deletestudentdata', $context),
 ];
 
 // Handle delete confirmation view
@@ -242,6 +247,7 @@ if ($participants) {
             'is_completed' => ($p->is_completed == 1),
             'date_completed' => userdate($p->timemodified, get_string('strftimedatetimeshort')),
             'view_url' => (new moodle_url('/blocks/chaside/view_results.php', ['userid' => $p->userid, 'courseid' => $courseid]))->out(false),
+            'can_delete' => has_capability('block/chaside:deletestudentdata', $context),
             'delete_url' => (new moodle_url('/blocks/chaside/admin_view.php', ['courseid' => $courseid, 'action' => 'delete', 'userid' => $p->userid, 'sesskey' => sesskey()]))->out(false)
         ];
 

--- a/block_chaside.php
+++ b/block_chaside.php
@@ -48,10 +48,10 @@ class block_chaside extends block_base {
         }
         $data['showdescriptions'] = $showdescriptions;
 
-        // Check if user can manage responses (teacher/admin)
-        if (has_capability('block/chaside:manage_responses', $context)) {
-            $data['management'] = $this->get_management_summary_data($context);
-            $data['showmanagement'] = true;
+        // Las cifras y resultados solo están disponibles en el panel protegido.
+        if (has_capability('block/chaside:viewstudentdata', $context)) {
+            $this->content->text = $this->get_management_launcher();
+            return $this->content;
         } else if (has_capability('block/chaside:take_test', $context)) {
             // Student view: check if test is completed (in any course)
             $response = $DB->get_record('block_chaside_responses', array(
@@ -78,6 +78,18 @@ class block_chaside extends block_base {
         }
            
         return $this->content;
+    }
+
+    private function get_management_launcher() {
+        global $COURSE, $OUTPUT;
+
+        return $OUTPUT->render_from_template('block_chaside/admin_launcher', [
+            'icon_html' => '<img src="' . (new moodle_url('/blocks/chaside/pix/icon.svg'))->out(false) . '" alt="" style="width: 4.25rem; height: 4.25rem; display: block; margin: 0 auto;">',
+            'security_label' => get_string('sensitive_data', 'block_chaside'),
+            'title' => get_string('management_title', 'block_chaside'),
+            'admin_url' => (new moodle_url('/blocks/chaside/admin_view.php', ['courseid' => $COURSE->id]))->out(false),
+            'button_label' => get_string('open_admin_panel', 'block_chaside'),
+        ]);
     }
 
     private function get_management_summary_data($context) {

--- a/db/access.php
+++ b/db/access.php
@@ -39,23 +39,16 @@ $capabilities = array(
         )
     ),
 
-    'block/chaside:viewreports' => array(
+    // Datos de orientación vocacional: solo roles autorizados expresamente.
+    'block/chaside:viewstudentdata' => array(
+        'riskbitmask' => RISK_PERSONAL,
         'captype' => 'read',
-        'contextlevel' => CONTEXT_COURSE,
-        'archetypes' => array(
-            'teacher' => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        )
+        'contextlevel' => CONTEXT_COURSE
     ),
 
-    'block/chaside:manage_responses' => array(
-        'captype' => 'read',
-        'contextlevel' => CONTEXT_COURSE,
-        'archetypes' => array(
-            'teacher' => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        )
+    'block/chaside:deletestudentdata' => array(
+        'riskbitmask' => RISK_DATALOSS | RISK_PERSONAL,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE
     )
 );

--- a/delete_response.php
+++ b/delete_response.php
@@ -19,7 +19,7 @@ $context = context_course::instance($course->id);
 $adminviewurl = new moodle_url('/blocks/chaside/admin_view.php', array('courseid' => $courseid));
 
 require_login($course, false);
-require_capability('block/chaside:viewreports', $context);
+require_capability('block/chaside:deletestudentdata', $context);
 
 $response = $DB->get_record('block_chaside_responses', array('id' => $id), '*', MUST_EXIST);
 

--- a/lang/en/block_chaside.php
+++ b/lang/en/block_chaside.php
@@ -1,12 +1,14 @@
 <?php
+$string['chaside:viewstudentdata'] = 'View sensitive student data';
+$string['chaside:deletestudentdata'] = 'Delete sensitive student data';
+$string['sensitive_data'] = 'Sensitive data';
+$string['open_admin_panel'] = 'Open administration panel';
 // Block name and settings
 $string['pluginname'] = 'Vocational Guidance Exploration';
 $string['chaside'] = 'CHASIDE';
 $string['chaside:addinstance'] = 'Add a new CHASIDE block';
 $string['chaside:myaddinstance'] = 'Add a new CHASIDE block to My Page';
 $string['chaside:take_test'] = 'Take the CHASIDE test';
-$string['chaside:viewreports'] = 'View CHASIDE test reports';
-$string['chaside:manage_responses'] = 'Manage CHASIDE test responses';
 
 // Configuration
 $string['config_showdescriptions'] = 'Show descriptions';

--- a/lang/es/block_chaside.php
+++ b/lang/es/block_chaside.php
@@ -1,12 +1,14 @@
 <?php
+$string['chaside:viewstudentdata'] = 'Ver datos sensibles de estudiantes';
+$string['chaside:deletestudentdata'] = 'Eliminar datos sensibles de estudiantes';
+$string['sensitive_data'] = 'Datos sensibles';
+$string['open_admin_panel'] = 'Abrir panel de administración';
 // Block name and settings
 $string['pluginname'] = 'Exploración de Orientación Vocacional';
 $string['chaside'] = 'CHASIDE';
 $string['chaside:addinstance'] = 'Añadir un nuevo bloque CHASIDE';
 $string['chaside:myaddinstance'] = 'Añadir un nuevo bloque CHASIDE a Mi Página';
 $string['chaside:take_test'] = 'Realizar el test CHASIDE';
-$string['chaside:viewreports'] = 'Ver reportes del test CHASIDE';
-$string['chaside:manage'] = 'Gestionar el test CHASIDE';
 
 // Configuración
 $string['config_showdescriptions'] = 'Mostrar descripciones';

--- a/lib.php
+++ b/lib.php
@@ -26,7 +26,7 @@ function block_chaside_get_completed_responses($courseid, $groupid = 0) {
     require_login($course, false);
     
     // Check permissions
-    if (!has_capability('block/chaside:viewreports', $context) && !has_capability('block/chaside:manage_responses', $context)) {
+    if (!has_capability('block/chaside:viewstudentdata', $context)) {
         return false;
     }
     
@@ -66,7 +66,7 @@ function block_chaside_get_student_ids($context, $groupid = 0) {
     foreach ($enrolled_ids as $candidateid) {
         $candidateid = (int)$candidateid;
         
-        if (has_capability('block/chaside:viewreports', $context, $candidateid) || has_capability('block/chaside:manage_responses', $context, $candidateid)) {
+        if (has_capability('block/chaside:viewstudentdata', $context, $candidateid)) {
             continue;
         }
         $student_ids[] = $candidateid;

--- a/styles.css
+++ b/styles.css
@@ -72,13 +72,15 @@
 }
 
 .block_chaside .chaside-invitation-block .chaside-actions .btn-primary {
-    background-color: #ffb600 !important;
+    background: linear-gradient(135deg, #ffb600 0%, #e6a300 100%) !important;
     border-color: #ffb600 !important;
+    color: #fff !important;
 }
 
 .block_chaside .chaside-invitation-block .chaside-actions .btn-primary:hover {
-    background-color: #e6a300 !important;
+    background: linear-gradient(135deg, #e6a300 0%, #cc9100 100%) !important;
     border-color: #cc9100 !important;
+    color: #fff !important;
 }
 
 .block_chaside .chaside-invitation-block .chaside-actions .btn:hover {

--- a/templates/admin_launcher.mustache
+++ b/templates/admin_launcher.mustache
@@ -1,0 +1,6 @@
+<div class="savio-admin-launcher text-center" style="padding: 1.25rem 1rem; border: 1px solid #f1e3bd; border-radius: 14px; background: linear-gradient(145deg, #fffdf8 0%, #fff7df 100%); box-shadow: 0 8px 20px rgba(183, 130, 15, .10);">
+    <div style="margin: 0 auto .85rem; line-height: 0;">{{{icon_html}}}</div>
+    <div class="small font-weight-bold text-uppercase" style="letter-spacing: .07em; color: #9b6d00;"><i class="fa fa-lock mr-1"></i>{{security_label}}</div>
+    <h6 class="mt-2 mb-2 font-weight-bold">{{title}}</h6>
+    <a href="{{admin_url}}" class="btn btn-sm btn-block" style="background: linear-gradient(135deg, #ffb600 0%, #e69d00 100%); border: 0; color: #fff !important; font-weight: 700; border-radius: 8px;"><i class="fa fa-arrow-right mr-1"></i>{{button_label}}</a>
+</div>

--- a/templates/admin_view.mustache
+++ b/templates/admin_view.mustache
@@ -213,9 +213,11 @@
                                     <a href="{{view_url}}" class="btn btn-sm btn-info mr-2 mt-1 mb-1" title="{{#str}}viewresults, block_chaside{{/str}}">
                                         <i class="fa fa-eye"></i> {{#str}}view, block_chaside{{/str}}
                                     </a>
-                                    <a href="{{delete_url}}" class="btn btn-sm btn-danger" title="{{#str}}deleteresponse, block_chaside{{/str}}">
-                                        <i class="fa fa-trash"></i> {{#str}}delete{{/str}}
-                                    </a>
+                                    {{#can_delete}}
+                                        <a href="{{delete_url}}" class="btn btn-sm btn-danger" title="{{#str}}deleteresponse, block_chaside{{/str}}">
+                                            <i class="fa fa-trash"></i> {{#str}}delete{{/str}}
+                                        </a>
+                                    {{/can_delete}}
                                 </td>
                             </tr>
                             {{/list}}

--- a/version.php
+++ b/version.php
@@ -10,8 +10,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026011801; // YYYYMMDDXX (year, month, day, 2-digit version number).
+$plugin->version = 2026072800; // YYYYMMDDXX (year, month, day, 2-digit version number).
 $plugin->requires = 2022041900; // Moodle 4.0+
 $plugin->component = 'block_chaside';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.0.3';
+$plugin->release = '2.0.4';

--- a/view.php
+++ b/view.php
@@ -29,7 +29,7 @@ if (!$DB->record_exists('block_instances', array('blockname' => 'chaside', 'pare
 }
 
 // Redirect teachers/admins to admin page
-if (has_capability('block/chaside:manage_responses', $context)) {
+if (has_capability('block/chaside:viewstudentdata', $context)) {
     $manage_url = new moodle_url('/blocks/chaside/admin_view.php', array('courseid' => $courseid));
     redirect($manage_url, get_string('teachers_redirect_message', 'block_chaside'));
 }

--- a/view_results.php
+++ b/view_results.php
@@ -27,7 +27,7 @@ if (!$DB->record_exists('block_instances', array('blockname' => 'chaside', 'pare
 }
 
 // Verificar permisos (redirreción silenciosa como learning_style/personality_test)
-if ($userid != $USER->id && !has_capability('block/chaside:viewreports', $context)) {
+if ($userid != $USER->id && !has_capability('block/chaside:viewstudentdata', $context)) {
     redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
 }
 
@@ -73,7 +73,7 @@ $template_data = [
     'iconurl' => $OUTPUT->image_url('icon', 'block_chaside')->out(false),
     'course_url' => (new moodle_url('/course/view.php', ['id' => $courseid]))->out(false),
     'admin_url' => (new moodle_url('/blocks/chaside/admin_view.php', ['courseid' => $courseid]))->out(false),
-    'can_view_reports' => has_capability('block/chaside:viewreports', $context),
+    'can_view_reports' => has_capability('block/chaside:viewstudentdata', $context),
     'str_back_to_course' => get_string('back_to_course', 'block_chaside'),
     'str_back_to_admin' => get_string('back_to_admin', 'block_chaside'),
 ];


### PR DESCRIPTION
## Resumen
- Reemplaza las métricas visibles del curso por un acceso compacto al panel administrativo.
- Protege consulta, resultados y exportación con `block/chaside:viewstudentdata`.
- Separa el borrado con `block/chaside:deletestudentdata`.
- Elimina las capacidades inactivas `viewreports` y `manage_responses`, y actualiza textos y CHANGELOG.

## Validación
- Sintaxis PHP validada.
- Actualización y comprobaciones de Moodle completadas correctamente.